### PR TITLE
Refine hero and navigation with DaisyUI primitives

### DIFF
--- a/src/components/GlitchText.astro
+++ b/src/components/GlitchText.astro
@@ -1,0 +1,16 @@
+---
+interface Props {
+        text: string;
+        as?: keyof HTMLElementTagNameMap;
+        class?: string;
+}
+
+const { text, as = "span", class: className = "" } = Astro.props as Props;
+const Tag = as;
+const classes = ["glitch-effect", "font-glitch", className].filter(Boolean).join(" ");
+const glitchValue = text.replace(/"/g, '\\"');
+---
+
+<Tag class={classes} data-text={text} style={`--glitch-text:"${glitchValue}"`}>
+        {text}
+</Tag>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,52 +1,128 @@
 ---
-import avatarPlaceholder from '../assets/images/avatar-placeholder.svg';
+import headshotImage from "../assets/images/nick-headshot.png";
+import GlitchText from "./GlitchText.astro";
+import LucideIcon from "./icons/LucideIcon.astro";
+import { heroContent } from "../data/hero";
+
+const { name, floatingBadges, stickers, ctas, statement, scrollCta, portraitAlt } = heroContent;
+
+const stickerPositionClasses: Record<string, string> = {
+        "top-left": "absolute -top-6 left-12",
+        "top-right": "absolute -top-8 -right-8",
+        "bottom-left": "absolute -bottom-8 -left-8",
+        "bottom-right": "absolute -bottom-8 -right-8",
+        "top-center": "absolute -top-8 left-1/2 -translate-x-1/2",
+        "bottom-center": "absolute -bottom-8 left-1/2 -translate-x-1/2",
+        "middle-left": "absolute top-1/2 -left-12 -translate-y-1/2",
+        "middle-right": "absolute top-1/2 -right-12 -translate-y-1/2",
+};
+
+const stickerSizeClasses: Record<string, string> = {
+        sm: "px-3 py-1.5 text-xs",
+        md: "px-4 py-2 text-sm",
+        lg: "px-5 py-3 text-base",
+};
+
+const ctaClasses: Record<string, string> = {
+        primary: "btn btn-lg btn-primary hero-btn hero-btn-primary",
+        secondary: "btn btn-lg btn-secondary hero-btn hero-btn-secondary",
+};
 ---
+<section
+        id="hero"
+        class="hero hero-home relative overflow-hidden bg-gradient-to-br from-base-100 via-cyan-50 to-lime-50 pt-12 texture-grid-paper"
+>
+        <div class="hero-content mx-auto flex min-h-[85vh] w-full max-w-7xl flex-col justify-center gap-14 px-4 py-12 text-center sm:px-6 lg:px-8 lg:gap-20 lg:py-16">
+                <div class="flex flex-wrap justify-center gap-4 lg:gap-6">
+                        {floatingBadges.map((badge) => (
+                                <span
+                                        class={`badge hero-badge hero-badge-floating px-4 py-2 ${badge.colorClass} ${badge.textClass ?? "text-black"}`}
+                                        style={`--badge-rotation:${badge.rotation}deg;`}
+                                >
+                                        <LucideIcon name={badge.icon} class="h-4 w-4" />
+                                        <span>{badge.label}</span>
+                                </span>
+                        ))}
+                </div>
 
-<div class="hero min-h-screen bg-gradient-to-br from-primary/10 to-secondary/10">
-  <div class="hero-content text-center">
-    <div class="max-w-4xl">
-      <div class="avatar mb-8">
-        <div class="w-32 rounded-full ring ring-primary ring-offset-base-100 ring-offset-2">
-          <img src={avatarPlaceholder.src} width={128} height={128} alt="Nick Roth" loading="lazy" />
-        </div>
-      </div>
-      <h1 class="text-5xl font-bold mb-2">Nick Roth</h1>
-      <p class="text-2xl mb-4 text-base-content/80">Product & Systems Director</p>
-      <p class="text-lg mb-8 max-w-3xl mx-auto leading-relaxed">
-        Transforming complex requirements into systematic solutions through objective-first discovery and automation-driven execution.
-      </p>
-      
-      <!-- Key Metrics -->
-      <div class="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8 max-w-4xl mx-auto">
-        <div class="stat bg-base-200/50 rounded-lg p-4">
-          <div class="stat-value text-2xl text-primary">400%</div>
-          <div class="stat-desc text-sm">YoY blog revenue increase</div>
-        </div>
-        <div class="stat bg-base-200/50 rounded-lg p-4">
-          <div class="stat-value text-2xl text-primary">$35k</div>
-          <div class="stat-desc text-sm">monthly cost savings</div>
-        </div>
-        <div class="stat bg-base-200/50 rounded-lg p-4">
-          <div class="stat-value text-2xl text-primary">150%</div>
-          <div class="stat-desc text-sm">organic user growth</div>
-        </div>
-        <div class="stat bg-base-200/50 rounded-lg p-4">
-          <div class="stat-value text-2xl text-primary">125%</div>
-          <div class="stat-desc text-sm">mobile revenue growth</div>
-        </div>
-      </div>
+                <div class="flex flex-col items-center justify-center gap-12 lg:flex-row lg:items-end lg:justify-between lg:gap-20">
+                        <div class="order-2 text-center lg:order-1 lg:text-left">
+                                <h1 class="text-7xl font-display font-black leading-none text-black md:text-9xl">
+                                        <GlitchText text={name.first} class="block" />
+                                        <span class="mt-4 inline-block -rotate-2 border-[6px] border-black bg-gradient-to-r from-fuchsia-500 to-purple-600 px-4 py-2 text-white shadow-[8px_8px_0px_0px_rgba(0,0,0,1)]">
+                                                <GlitchText text={name.last} />
+                                        </span>
+                                </h1>
+                        </div>
 
-      <div class="flex gap-4 justify-center flex-wrap">
-        <a href="/work" class="btn btn-primary btn-lg">View My Work</a>
-        <a href="/contact" class="btn btn-outline btn-lg">Get In Touch</a>
-      </div>
-      
-      <div class="mt-8">
-        <p class="text-sm text-base-content/60">
-          <span class="inline-block mr-4">📍 Huntsville, AL</span>
-          <span class="inline-block">✅ Open to consulting and fractional roles</span>
-        </p>
-      </div>
-    </div>
-  </div>
-</div>
+                        <div class="order-1 lg:order-2">
+                                <div class="relative inline-flex hero-portrait-cluster">
+                                        <div class="pointer-events-none absolute -inset-8">
+                                                <div class="hero-shape hero-shape-square"></div>
+                                                <div class="hero-shape hero-shape-circle"></div>
+                                                <div class="hero-shape hero-shape-bar"></div>
+                                        </div>
+
+                                        <div class="hero-portrait-frame">
+                                                <div class="hero-portrait-inner">
+                                                        <div class="overflow-hidden border-4 border-black bg-white shadow-[4px_4px_0px_0px_rgba(0,0,0,1)]">
+                                                                <img
+                                                                        src={headshotImage.src}
+                                                                        alt={portraitAlt}
+                                                                        width={384}
+                                                                        height={384}
+                                                                        loading="lazy"
+                                                                        class="h-80 w-80 object-cover md:h-96 md:w-96"
+                                                                />
+                                                        </div>
+                                                </div>
+                                        </div>
+
+                                        {stickers.map((sticker) => {
+                                                const positionClass = stickerPositionClasses[sticker.position] ?? "";
+                                                const sizeClass = stickerSizeClasses[sticker.size ?? "md"];
+
+                                                return (
+                                                        <span
+                                                                class={`badge hero-badge hero-badge-sticker ${sizeClass} ${positionClass} ${sticker.colorClass} ${sticker.textClass ?? "text-black"}`}
+                                                                style={`--badge-rotation:${sticker.rotation}deg;`}
+                                                        >
+                                                                {sticker.label}
+                                                        </span>
+                                                );
+                                        })}
+                                </div>
+                        </div>
+                </div>
+
+                <div class="relative mx-auto max-w-4xl">
+                        <div class="card hero-statement-card">
+                                <div class="card-body">
+                                        <p class="m-0 text-2xl font-black leading-relaxed text-black md:text-3xl">
+                                                {statement.leading} <span class="hero-statement-highlight">{statement.highlight}</span> {statement.trailing}
+                                        </p>
+                                </div>
+                        </div>
+                        <div class="hero-statement-accent hero-statement-accent-square"></div>
+                        <div class="hero-statement-accent hero-statement-accent-bar"></div>
+                </div>
+
+                <div class="flex flex-col items-center gap-6 sm:flex-row sm:justify-center">
+                        {ctas.map((cta) => (
+                                <a href={cta.href} class={ctaClasses[cta.variant]}>
+                                        <span>{cta.label}</span>
+                                </a>
+                        ))}
+                </div>
+        </div>
+
+        <div class="absolute bottom-8 left-1/2 hidden -translate-x-1/2 sm:block">
+                <a
+                        href={scrollCta.href}
+                        class="btn btn-circle btn-outline hero-scroll-btn"
+                        aria-label={scrollCta.label}
+                >
+                        <LucideIcon name="arrow-down" class="h-6 w-6" />
+                </a>
+        </div>
+</section>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,92 +1,145 @@
 ---
-import avatarPlaceholder from "../assets/images/avatar-placeholder.svg";
-
-type NavItem = {
-	href: string;
-	label: string;
-};
+import GlitchText from "./GlitchText.astro";
+import LucideIcon from "./icons/LucideIcon.astro";
+import { navigationData } from "../data/navigation";
 
 interface Props {
-	currentPath?: string;
+        currentPath?: string;
 }
 
 const { currentPath = "/" } = Astro.props as Props;
 
 const normalizePath = (path: string) => {
-	if (!path) return "/";
-	return path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
+        if (!path) return "/";
+        return path.length > 1 && path.endsWith("/") ? path.slice(0, -1) : path;
 };
 
 const normalizedCurrentPath = normalizePath(currentPath);
 
-const isActive = (href: string) => {
-	const normalizedHref = normalizePath(href);
-	if (normalizedHref === "/") {
-		return normalizedCurrentPath === "/";
-	}
-	return (
-		normalizedCurrentPath === normalizedHref ||
-		normalizedCurrentPath.startsWith(`${normalizedHref}/`)
-	);
+const getActivePath = (path: string) => {
+        if (path.startsWith("/writing/") || path === "/writing") {
+                return "/writing";
+        }
+        if (path.startsWith("/demo")) {
+                return "/demo";
+        }
+        return path;
 };
 
-const navItems: NavItem[] = [
-	{ href: "/work", label: "Work" },
-	{ href: "/approach", label: "Approach" },
-	{ href: "/background", label: "Background" },
-	{ href: "/contact", label: "Contact" },
-	{ href: "/showcase", label: "Showcase" },
-	{ href: "/project", label: "Project" },
-];
+const activePath = getActivePath(normalizedCurrentPath);
 
-const mobileLinkClass = (href: string) =>
-	isActive(href) ? "active font-semibold" : "";
+const isActive = (href: string) => getActivePath(normalizePath(href)) === activePath;
 
-const desktopLinkClass = (href: string) =>
-	`px-3 py-2 rounded-lg transition-colors ${
-		isActive(href) ? "bg-primary text-primary-content" : "hover:bg-base-200"
-	}`;
+const { brand, items, demoItems } = navigationData;
 ---
+<a
+        href="#main"
+        class="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 bg-black text-white px-4 py-2 border-2 border-black shadow-[2px_2px_0px_0px_rgba(255,255,255,1)] z-50"
+>
+        Skip to main content
+</a>
+<nav class="navbar nav-surface fixed top-0 left-0 right-0 z-40">
+        <div class="nav-shell mx-auto flex h-16 w-full max-w-7xl items-center justify-between gap-4 px-4">
+                <div class="navbar-start">
+                        <a href="/" class="nav-brand relative inline-flex items-center gap-2" aria-label="Nick Roth home">
+                                <span class="text-xl font-display font-black leading-none text-black">
+                                        <GlitchText text={brand.first} />
+                                </span>
+                                <span class="inline-flex -rotate-1 items-center border-2 border-black bg-gradient-to-r from-fuchsia-500 to-purple-600 px-2 py-1 font-display text-xl font-black text-white shadow-[3px_3px_0px_0px_rgba(0,0,0,1)]">
+                                        <GlitchText text={brand.last} />
+                                </span>
+                                <span class="absolute -top-1 -right-1 h-1.5 w-1.5 rounded-full border border-black bg-lime-400"></span>
+                                <span class="absolute -bottom-1 -left-1 h-2 w-1 rotate-45 border border-black bg-cyan-400"></span>
+                        </a>
+                </div>
 
-<div class="navbar bg-base-100 border-b-4 border-black h-16 items-center">
-	<div class="navbar-start">
-		<div class="dropdown">
-			<div tabindex="0" role="button" class="btn btn-ghost lg:hidden">
-				<svg class="w-5 h-5" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 17 14">
-					<path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M1 1h15M1 7h15M1 13h15" />
-				</svg>
-			</div>
-			<ul tabindex="0" class="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52">
-								{navItems.map((item: NavItem) => (
-									<li>
-						<a href={item.href} class={mobileLinkClass(item.href)}>{item.label}</a>
-					</li>
-				))}
-			</ul>
-		</div>
-		<a href="/" class={`btn btn-ghost text-xl ${isActive('/') ? 'btn-active' : ''}`}>
-			<div class="avatar">
-				<div class="w-8 rounded-full">
-					<img src={avatarPlaceholder.src} alt="Nick Roth" loading="lazy" />
-				</div>
-			</div>
-			Nick Roth
-		</a>
-	</div>
-	<div class="navbar-center hidden lg:flex h-full items-center">
-		<ul class="menu menu-horizontal px-1 h-full items-center">
-							{navItems.map((item: NavItem) => (
-								<li class="h-full flex items-center">
-					<a href={item.href} class={desktopLinkClass(item.href)}>{item.label}</a>
-				</li>
-			))}
-		</ul>
-	</div>
-	<div class="navbar-end">
-		<label class="swap swap-rotate">
-			<input type="checkbox" class="theme-controller" value="neobrutalism-dark" />
-			<svg class="swap-off fill-current w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M5.64,17l-.71.71a1,1,0,0,0,0,1.41,1,1,0,0,0,1.41,0l.71-.71A1,1,0,0,0,5.64,17ZM5,12a1,1,0,0,0-1-1H3a1,1,0,0,0,0,2H4A1,1,0,0,0,5,12Zm7-7a1,1,0,0,0,1-1V3a1,1,0,0,0-2,0V4A1,1,0,0,0,12,5ZM5.64,7.05a1,1,0,0,0,.7.29,1,1,0,0,0,.71-.29,1,1,0,0,0,0-1.41l-.71-.71A1,1,0,0,0,4.93,6.34Zm12,.29a1,1,0,0,0,.7-.29l.71-.71a1,1,0,1,0-1.41-1.41L17,5.64a1,1,0,0,0,0,1.41A1,1,0,0,0,17.66,7.34ZM21,11H20a1,1,0,0,0,0,2h1a1,1,0,0,0,0-2Zm-9,8a1,1,0,0,0-1,1v1a1,1,0,0,0,2,0V20A1,1,0,0,0,12,19ZM18.36,17A1,1,0,0,0,17,18.36l.71.71a1,1,0,0,0,1.41,0,1,1,0,0,0,0-1.41ZM12,6.5A5.5,5.5,0,1,0,17.5,12,5.51,5.51,0,0,0,12,6.5Zm0,9A3.5,3.5,0,1,1,15.5,12,3.5,3.5,0,0,1,12,15.5Z" /></svg>
-			<svg class="swap-on fill-current w-6 h-6" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"><path d="M21.64,13a1,1,0,0,0-1.05-.14,8.05,8.05,0,0,1-3.37.73A8.15,8.15,0,0,1,9.08,5.49a8.59,8.59,0,0,1,.25-2A1,1,0,0,0,8,2.36,10.14,10.14,0,1,0,22,14.05,1,1,0,0,0,21.64,13Zm-9.5,6.69A8.14,8.14,0,0,1,7.08,5.22v.27A10.15,10.15,0,0,0,17.22,15.63a9.79,9.79,0,0,0,2.1-.22A8.11,8.11,0,0,1,12.14,19.73Z" /></svg>
-		</label>
-	</div>
-</div>
+                <div class="navbar-center hidden md:flex">
+                        <ul class="menu menu-horizontal items-center gap-2">
+                                {items.map((item) => (
+                                        <li>
+                                                <a
+                                                        href={item.href}
+                                                        class={`btn btn-sm btn-nav ${isActive(item.href) ? "btn-nav-active" : "btn-nav-default"}`}
+                                                        aria-current={isActive(item.href) ? "page" : undefined}
+                                                >
+                                                        <LucideIcon name={item.icon} class="h-4 w-4" />
+                                                        <span>{item.label}</span>
+                                                </a>
+                                        </li>
+                                ))}
+                                <li>
+                                        <div class="dropdown dropdown-hover dropdown-end">
+                                                <label
+                                                        tabindex="0"
+                                                        class={`btn btn-sm btn-nav ${
+                                                                activePath === "/demo" ? "btn-nav-active" : "btn-nav-default"
+                                                        }`}
+                                                        aria-haspopup="true"
+                                                        aria-expanded={activePath === "/demo"}
+                                                >
+                                                        <LucideIcon name="zap" class="h-4 w-4" />
+                                                        <span>Demo</span>
+                                                        <LucideIcon name="chevron-down" class="h-3 w-3 nav-chevron" ariaHidden={true} />
+                                                </label>
+                                                <ul
+                                                        tabindex="0"
+                                                        class="menu menu-sm dropdown-content nav-dropdown-panel mt-3 w-72 gap-2 p-3"
+                                                >
+                                                        {demoItems.map((item) => (
+                                                                <li>
+                                                                        <a href={item.href} class="nav-dropdown-link">
+                                                                                <span class="font-bold text-black">{item.label}</span>
+                                                                                <span class="text-sm text-gray-600">{item.description}</span>
+                                                                        </a>
+                                                                </li>
+                                                        ))}
+                                                </ul>
+                                        </div>
+                                </li>
+                        </ul>
+                </div>
+
+                <div class="navbar-end md:hidden">
+                        <details class="dropdown dropdown-end nav-mobile-toggle">
+                                <summary class="btn btn-square btn-nav btn-nav-default">
+                                        <span class="sr-only">Toggle navigation</span>
+                                        <span class="icon-open flex">
+                                                <LucideIcon name="menu" class="h-6 w-6" ariaHidden={true} />
+                                        </span>
+                                        <span class="icon-close hidden">
+                                                <LucideIcon name="x" class="h-6 w-6" ariaHidden={true} />
+                                        </span>
+                                </summary>
+                                <div class="dropdown-content nav-mobile-panel">
+                                        <ul class="menu menu-vertical gap-3">
+                                                {items.map((item) => (
+                                                        <li>
+                                                                <a
+                                                                        href={item.href}
+                                                                        class={`btn btn-nav btn-nav-block ${
+                                                                                isActive(item.href)
+                                                                                        ? "btn-nav-active"
+                                                                                        : "btn-nav-default"
+                                                                        }`}
+                                                                        aria-current={isActive(item.href) ? "page" : undefined}
+                                                                >
+                                                                        <LucideIcon name={item.icon} class="h-4 w-4" />
+                                                                        <span>{item.label}</span>
+                                                                </a>
+                                                        </li>
+                                                ))}
+                                                <li class="menu-title nav-mobile-status">Demo</li>
+                                                {demoItems.map((item) => (
+                                                        <li>
+                                                                <a href={item.href} class="btn btn-nav btn-nav-block btn-nav-default">
+                                                                        <LucideIcon name="zap" class="h-4 w-4" />
+                                                                        <span>Demo • {item.label}</span>
+                                                                </a>
+                                                        </li>
+                                                ))}
+                                        </ul>
+                                </div>
+                        </details>
+                </div>
+        </div>
+</nav>

--- a/src/components/icons/LucideIcon.astro
+++ b/src/components/icons/LucideIcon.astro
@@ -1,0 +1,50 @@
+---
+import type { LucideIconDefinition, LucideIconName } from "../../icons/lucide";
+import { lucideIcons } from "../../icons/lucide";
+
+interface Props {
+        name: LucideIconName;
+        class?: string;
+        strokeWidth?: number;
+        title?: string;
+        ariaHidden?: boolean;
+}
+
+const {
+        name,
+        class: className = "w-4 h-4",
+        strokeWidth = 2,
+        title,
+        ariaHidden = true,
+} = Astro.props as Props;
+
+const icon = lucideIcons[name] as LucideIconDefinition;
+
+if (!icon) {
+        throw new Error(`Lucide icon \"${name}\" is not defined.`);
+}
+
+const labelled = Boolean(title);
+---
+<svg
+        class:list={["lucide", `lucide-${name}`, className]}
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width={strokeWidth}
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        role={labelled ? "img" : undefined}
+        aria-hidden={labelled ? undefined : ariaHidden ? "true" : undefined}
+>
+        {title && <title>{title}</title>}
+        {icon.paths?.map((d) => (
+                <path d={d} />
+        ))}
+        {icon.circles?.map((circle) => (
+                <circle cx={circle.cx} cy={circle.cy} r={circle.r} />
+        ))}
+</svg>

--- a/src/data/hero.ts
+++ b/src/data/hero.ts
@@ -1,0 +1,132 @@
+import type { LucideIconName } from "../icons/lucide";
+
+type StickerPosition =
+        | "top-left"
+        | "top-right"
+        | "bottom-left"
+        | "bottom-right"
+        | "top-center"
+        | "bottom-center"
+        | "middle-left"
+        | "middle-right";
+
+export type HeroSticker = {
+        label: string;
+        position: StickerPosition;
+        rotation: number;
+        colorClass: string;
+        textClass?: string;
+        size?: "sm" | "md" | "lg";
+};
+
+export type HeroCtaVariant = "primary" | "secondary";
+
+export type HeroCta = {
+        label: string;
+        href: string;
+        variant: HeroCtaVariant;
+};
+
+export type HeroFloatingBadge = {
+        label: string;
+        icon: LucideIconName;
+        rotation: number;
+        colorClass: string;
+        textClass?: string;
+};
+
+export type HeroContent = {
+        name: {
+                first: string;
+                last: string;
+        };
+        floatingBadges: HeroFloatingBadge[];
+        stickers: HeroSticker[];
+        ctas: HeroCta[];
+        statement: {
+                leading: string;
+                highlight: string;
+                trailing: string;
+        };
+        scrollCta: {
+                label: string;
+                href: string;
+        };
+        portraitAlt: string;
+};
+
+export const heroContent: HeroContent = {
+        name: {
+                first: "NICK",
+                last: "ROTH",
+        },
+        floatingBadges: [
+                {
+                        label: "FULL-STACK PM",
+                        icon: "zap",
+                        rotation: -8,
+                        colorClass: "bg-lime-300",
+                        textClass: "text-black",
+                },
+                {
+                        label: "AI ENGINEER",
+                        icon: "brain",
+                        rotation: 5,
+                        colorClass: "bg-cyan-300",
+                        textClass: "text-black",
+                },
+                {
+                        label: "AUTOMATION",
+                        icon: "code",
+                        rotation: -3,
+                        colorClass: "bg-yellow-300",
+                        textClass: "text-black",
+                },
+        ],
+        stickers: [
+                {
+                        label: "PRODUCT",
+                        position: "top-right",
+                        rotation: 12,
+                        colorClass: "bg-fuchsia-500",
+                        textClass: "text-white",
+                        size: "lg",
+                },
+                {
+                        label: "ENGINEER",
+                        position: "bottom-left",
+                        rotation: -12,
+                        colorClass: "bg-yellow-300",
+                        textClass: "text-black",
+                        size: "lg",
+                },
+                {
+                        label: "AI",
+                        position: "middle-right",
+                        rotation: 90,
+                        colorClass: "bg-lime-400",
+                        textClass: "text-black",
+                },
+                {
+                        label: "GT MS",
+                        position: "top-left",
+                        rotation: -6,
+                        colorClass: "bg-black",
+                        textClass: "text-white font-mono",
+                },
+        ],
+        ctas: [
+                { label: "View my work", href: "/work", variant: "primary" },
+                { label: "Let's talk", href: "/contact", variant: "secondary" },
+        ],
+        statement: {
+                leading: "I turn business objectives into",
+                highlight: "shippable systems",
+                trailing: "— model the business, specify precisely, and build only what moves the needle.",
+        },
+        scrollCta: {
+                label: "Scroll to process",
+                href: "#process",
+        },
+        portraitAlt: "Nick Roth",
+};

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,0 +1,43 @@
+import type { LucideIconName } from "../icons/lucide";
+
+export type NavigationItem = {
+        href: string;
+        label: string;
+        icon: LucideIconName;
+};
+
+export type NavigationDemoItem = {
+        href: string;
+        label: string;
+        description: string;
+};
+
+export type NavigationData = {
+        brand: {
+                first: string;
+                last: string;
+        };
+        items: NavigationItem[];
+        demoItems: NavigationDemoItem[];
+};
+
+export const navigationData: NavigationData = {
+        brand: {
+                first: "NICK",
+                last: "ROTH",
+        },
+        items: [
+                { href: "/", label: "Home", icon: "home" },
+                { href: "/focus", label: "Focus", icon: "target" },
+                { href: "/background", label: "Background", icon: "user" },
+                { href: "/writing", label: "Writing", icon: "file-text" },
+        ],
+        demoItems: [
+                { href: "/demo/cards", label: "Cards", description: "Card component showcase" },
+                { href: "/demo/typography", label: "Typography", description: "Text and heading components" },
+                { href: "/demo/buttons", label: "Buttons", description: "Interactive button components" },
+                { href: "/demo/ui-elements", label: "UI Elements", description: "Badges, dividers, and form elements" },
+                { href: "/demo/list-components", label: "Lists", description: "Navigation and list-based components" },
+                { href: "/demo/blog-components", label: "Blog", description: "Quotes, callouts, and long-form UI" },
+        ],
+};

--- a/src/icons/lucide.ts
+++ b/src/icons/lucide.ts
@@ -1,0 +1,67 @@
+export type LucideIconDefinition = {
+        paths?: string[];
+        circles?: Array<{ cx: number; cy: number; r: number }>;
+};
+
+export const lucideIcons = {
+        home: {
+                paths: [
+                        "M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8",
+                        "M3 10a2 2 0 0 1 .709-1.528l7-6a2 2 0 0 1 2.582 0l7 6A2 2 0 0 1 21 10v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z",
+                ],
+        },
+        target: {
+                circles: [
+                        { cx: 12, cy: 12, r: 10 },
+                        { cx: 12, cy: 12, r: 6 },
+                        { cx: 12, cy: 12, r: 2 },
+                ],
+        },
+        user: {
+                paths: ["M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"],
+                circles: [{ cx: 12, cy: 7, r: 4 }],
+        },
+        "file-text": {
+                paths: [
+                        "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z",
+                        "M14 2v4a2 2 0 0 0 2 2h4",
+                        "M10 9H8",
+                        "M16 13H8",
+                        "M16 17H8",
+                ],
+        },
+        zap: {
+                paths: [
+                        "M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z",
+                ],
+        },
+        "chevron-down": {
+                paths: ["m6 9 6 6 6-6"],
+        },
+        menu: {
+                paths: ["M4 5h16", "M4 12h16", "M4 19h16"],
+        },
+        x: {
+                paths: ["M18 6 6 18", "m6 6 12 12"],
+        },
+        "arrow-down": {
+                paths: ["M12 5v14", "m19 12-7 7-7-7"],
+        },
+        brain: {
+                paths: [
+                        "M12 18V5",
+                        "M15 13a4.17 4.17 0 0 1-3-4 4.17 4.17 0 0 1-3 4",
+                        "M17.598 6.5A3 3 0 1 0 12 5a3 3 0 1 0-5.598 1.5",
+                        "M17.997 5.125a4 4 0 0 1 2.526 5.77",
+                        "M18 18a4 4 0 0 0 2-7.464",
+                        "M19.967 17.483A4 4 0 1 1 12 18a4 4 0 1 1-7.967-.517",
+                        "M6 18a4 4 0 0 1-2-7.464",
+                        "M6.003 5.125a4 4 0 0 0-2.526 5.77",
+                ],
+        },
+        code: {
+                paths: ["m16 18 6-6-6-6", "m8 6-6 6 6 6"],
+        },
+} as const satisfies Record<string, LucideIconDefinition>;
+
+export type LucideIconName = keyof typeof lucideIcons;

--- a/src/pages/showcase/components/navigation.astro
+++ b/src/pages/showcase/components/navigation.astro
@@ -1,27 +1,124 @@
 ---
-import BaseLayout from '../../../layouts/BaseLayout.astro';
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import Navbar from "../../../components/Navbar.astro";
+import GlitchText from "../../../components/GlitchText.astro";
+import LucideIcon from "../../../components/icons/LucideIcon.astro";
+import { navigationData } from "../../../data/navigation";
+
+const { demoItems, items } = navigationData;
 ---
 
-<BaseLayout 
-  title="Navigation - Components" 
-  description="Navbar, menu, breadcrumbs, and navigation patterns."
+<BaseLayout
+  title="Navigation - Components"
+  description="Navbar, menu, and navigation patterns with glitch branding."
+  showNavbar={false}
 >
-  <div class="container mx-auto px-4 py-20 max-w-6xl">
-    <h1 class="text-5xl font-black mb-4">Navigation</h1>
-    <p class="text-xl text-base-content/70 mb-12">
-      Navigation components for site structure and wayfinding.
-    </p>
+  <div class="min-h-screen bg-base-200 py-20">
+    <div class="container mx-auto px-4 max-w-6xl space-y-16">
+      <header class="space-y-4 text-center">
+        <div class="inline-flex items-center gap-3">
+          <GlitchText text="NR//NAV" class="text-sm" />
+          <span class="badge badge-accent badge-sm shadow-brutal-sm">Showcase</span>
+        </div>
+        <h1 class="text-5xl font-black">Navigation System</h1>
+        <p class="mx-auto max-w-3xl text-xl text-base-content/70">
+          Glitch-branded navigation with icon-labeled pills and a hover-triggered demo dropdown — matching the exported
+          Figma build pixel-for-pixel across desktop and mobile breakpoints.
+        </p>
+      </header>
 
-    <!-- TODO: Navbar variations -->
-    <!-- TODO: Menu (vertical/horizontal) -->
-    <!-- TODO: Breadcrumbs -->
-    <!-- TODO: Tabs -->
-    <!-- TODO: Pagination -->
-    <!-- TODO: Drawer -->
-    
-    <div class="alert alert-warning shadow-brutal border-2 border-black dark:border-white">
-      <span>🚧 This page is under construction. Check back soon!</span>
+      <section class="space-y-6">
+        <h2 class="text-3xl font-black border-b-4 border-base-content inline-block pb-2">Default Light Mode</h2>
+        <p class="text-base text-base-content/70">
+          Fixed desktop bar with glitch lockup, icon buttons, and a hover-triggered demo menu sourced from shared data.
+        </p>
+        <div class="rounded-3xl border-4 border-black bg-base-100 shadow-brutal-xl overflow-hidden">
+          <Navbar currentPath="/showcase/components/navigation" />
+        </div>
+        <ul class="list-disc space-y-2 pl-6 text-base-content/70">
+          <li>Glitch lockup renders with <code class="bg-base-content/10 px-1">GlitchText</code> and the Space Grotesk display font.</li>
+          <li>Icon pills inherit active state from <code class="bg-base-content/10 px-1">Navbar</code>&rsquo;s pathname logic.</li>
+          <li>Hovering the Demo pill reveals the brutalist dropdown from the same data source used in production.</li>
+        </ul>
+      </section>
+
+      <section class="space-y-6">
+        <h2 class="text-3xl font-black border-b-4 border-base-content inline-block pb-2">Dark Mode Preview</h2>
+        <p class="text-base text-base-content/70">
+          Navigation automatically inverts borders and shadows when dark theme is applied.
+        </p>
+        <div data-theme="neobrutalism-dark" class="rounded-3xl border-4 border-white bg-base-300 shadow-brutal-xl overflow-hidden">
+          <Navbar currentPath="/work" />
+        </div>
+      </section>
+
+      <section class="space-y-6">
+        <h2 class="inline-block border-b-4 border-base-content pb-2 text-3xl font-black">Demo Dropdown &amp; Mobile Drawer</h2>
+        <p class="text-base text-base-content/70">
+          Desktop hover menu and mobile <code class="bg-base-content/10 px-1">&lt;details&gt;</code> share the same data. Both reuse the brutalist panel styling from the production navigation.
+        </p>
+        <div class="grid gap-6 lg:grid-cols-2">
+          <div class="rounded-3xl border-4 border-black bg-base-100 p-6 shadow-brutal-xl">
+            <div class="mb-4 text-sm uppercase tracking-[0.3em] text-base-content/60">Desktop dropdown</div>
+            <div class="dropdown dropdown-hover dropdown-end inline-block">
+              <label tabindex="0" class="btn btn-sm btn-nav btn-nav-default">
+                <LucideIcon name="zap" class="h-4 w-4" />
+                <span>Demo</span>
+                <LucideIcon name="chevron-down" class="h-3 w-3 nav-chevron" />
+              </label>
+              <ul tabindex="0" class="menu menu-sm dropdown-content nav-dropdown-panel mt-3 w-72 gap-2 p-3">
+                {demoItems.map((item) => (
+                  <li>
+                    <a href={item.href} class="nav-dropdown-link">
+                      <span class="font-bold text-black">{item.label}</span>
+                      <span class="text-sm text-gray-600">{item.description}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </div>
+
+          <div class="rounded-3xl border-4 border-black bg-base-100 p-6 shadow-brutal-xl">
+            <div class="mb-4 text-sm uppercase tracking-[0.3em] text-base-content/60">Mobile drawer</div>
+            <details class="dropdown dropdown-end nav-mobile-toggle relative w-full max-w-xs" open>
+              <summary class="btn btn-square btn-nav btn-nav-default">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="icon-open hidden">
+                  <LucideIcon name="menu" class="h-6 w-6" ariaHidden={true} />
+                </span>
+                <span class="icon-close flex">
+                  <LucideIcon name="x" class="h-6 w-6" ariaHidden={true} />
+                </span>
+              </summary>
+              <div class="dropdown-content nav-mobile-panel">
+                <ul class="menu menu-vertical gap-2">
+                  {items.map((item) => (
+                    <li>
+                      <a href={item.href} class="btn btn-nav btn-nav-block btn-nav-default">
+                        <LucideIcon name={item.icon} class="h-4 w-4" />
+                        <span>{item.label}</span>
+                      </a>
+                    </li>
+                  ))}
+                  <li class="menu-title nav-mobile-status">Demo</li>
+                  {demoItems.map((item) => (
+                    <li>
+                      <a href={item.href} class="btn btn-nav btn-nav-block btn-nav-default">
+                        <LucideIcon name="zap" class="h-4 w-4" />
+                        <span>Demo • {item.label}</span>
+                      </a>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </details>
+            <p class="mt-4 text-sm text-base-content/70">
+              Open state mirrors the site navigation: zap-tagged demo shortcuts sourced from the shared data file.
+            </p>
+          </div>
+        </div>
+      </section>
     </div>
   </div>
 </BaseLayout>
-```

--- a/src/pages/showcase/index.astro
+++ b/src/pages/showcase/index.astro
@@ -86,9 +86,15 @@ const categories = [
   {
     title: 'Patterns',
     pages: [
-      { 
-        title: 'Layouts', 
-        href: '/showcase/patterns/layouts', 
+      {
+        title: 'Hero',
+        href: '/showcase/patterns/hero',
+        description: 'Homepage hero with glitch branding and stickers',
+        icon: '🌅'
+      },
+      {
+        title: 'Layouts',
+        href: '/showcase/patterns/layouts',
         description: 'Section layouts and grid systems',
         icon: '📐'
       },

--- a/src/pages/showcase/patterns/hero.astro
+++ b/src/pages/showcase/patterns/hero.astro
@@ -1,0 +1,71 @@
+---
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+import HeroSection from "../../../components/Hero.astro";
+import { heroContent } from "../../../data/hero";
+
+const stickerPositionClasses: Record<string, string> = {
+  "top-left": "absolute -top-6 left-12",
+  "top-right": "absolute -top-8 -right-8",
+  "bottom-left": "absolute -bottom-8 -left-8",
+  "bottom-right": "absolute -bottom-8 -right-8",
+  "top-center": "absolute -top-8 left-1/2 -translate-x-1/2",
+  "bottom-center": "absolute -bottom-8 left-1/2 -translate-x-1/2",
+  "middle-left": "absolute top-1/2 -left-12 -translate-y-1/2",
+  "middle-right": "absolute top-1/2 -right-12 -translate-y-1/2",
+};
+
+const stickerSizeClasses: Record<string, string> = {
+  sm: "px-3 py-1 text-xs",
+  md: "px-4 py-2 text-sm",
+  lg: "px-5 py-2.5 text-base",
+};
+---
+
+<BaseLayout
+  title="Hero - Patterns"
+  description="Homepage hero with glitch branding, stickers, and CTA layout."
+  showNavbar={false}
+>
+  <div class="bg-base-200 min-h-screen">
+    <div class="space-y-12">
+      <section class="container mx-auto px-4 pt-20">
+        <div class="flex flex-col items-center text-center gap-4 mb-12">
+          <span class="badge badge-accent badge-sm shadow-brutal-sm">Homepage Pattern</span>
+          <h1 class="text-5xl font-black">Hero Block</h1>
+          <p class="text-xl text-base-content/70 max-w-3xl">
+            Full-width hero showcasing glitch branding, sticker badges, and CTA system. Hover over the portrait to trigger
+            rotation on both the background and headshot.
+          </p>
+        </div>
+        <div class="rounded-none lg:rounded-[2.5rem] border-4 border-black dark:border-white shadow-brutal-xl overflow-hidden">
+          <HeroSection />
+        </div>
+      </section>
+
+      <section class="container mx-auto space-y-8 px-4 pb-20">
+        <h2 class="inline-block border-b-4 border-base-content pb-2 text-3xl font-black">Sticker Layout</h2>
+        <p class="max-w-3xl text-base text-base-content/70">
+          Sticker text, colors, and rotations live in <code class="bg-base-content/10 px-2 py-1 rounded">src/data/hero.ts</code>. The
+          live hero and this preview both map that data to brutalist badges for consistent placement.
+        </p>
+        <div class="relative mx-auto max-w-md rounded-[2rem] border-4 border-black bg-base-100 p-12 shadow-brutal-xl">
+          <p class="mb-2 text-center font-bold uppercase tracking-[0.3em]">Sticker positions</p>
+          <p class="mb-10 text-center text-sm text-base-content/70">Hover each badge to see the rotate-and-lift micro-interaction.</p>
+          {heroContent.stickers.map((sticker) => {
+            const positionClass = stickerPositionClasses[sticker.position] ?? "";
+            const sizeClass = stickerSizeClasses[sticker.size ?? "md"];
+
+            return (
+              <span
+                class={`badge hero-badge hero-badge-sticker ${sticker.colorClass} ${sticker.textClass ?? "text-black"} ${sizeClass} ${positionClass}`}
+                style={`--badge-rotation:${sticker.rotation}deg;`}
+              >
+                {sticker.label}
+              </span>
+            );
+          })}
+        </div>
+      </section>
+    </div>
+  </div>
+</BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,4 @@
+@import url("https://fonts.googleapis.com/css2?family=Rubik+Glitch&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap");
 @import "tailwindcss";
 
 @plugin "daisyui" {
@@ -123,6 +124,579 @@
         --btn-shadow: 4px 4px 0px 0px var(--nr-shadow-color);
         --btn-shadow-colored: 4px 4px 0px 0px var(--nr-shadow-color);
         --rounded-btn: 0rem;
+    }
+
+    @layer base {
+        .font-glitch {
+            font-family: "Rubik Glitch", cursive;
+        }
+
+        .font-display {
+            font-family: "Space Grotesk", var(--tw-font-sans, ui-sans-serif, system-ui);
+        }
+
+        .font-mono {
+            font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        }
+    }
+
+    @layer components {
+        @keyframes glitch-1 {
+            0%,
+            100% {
+                transform: translate(0, 0);
+            }
+
+            10% {
+                transform: translate(-2px, -2px);
+            }
+
+            20% {
+                transform: translate(2px, 2px);
+            }
+
+            30% {
+                transform: translate(-2px, 2px);
+            }
+
+            40% {
+                transform: translate(2px, -2px);
+            }
+
+            50% {
+                transform: translate(-2px, -2px);
+            }
+
+            60% {
+                transform: translate(2px, 2px);
+            }
+
+            70% {
+                transform: translate(-2px, 2px);
+            }
+
+            80% {
+                transform: translate(2px, -2px);
+            }
+
+            90% {
+                transform: translate(-2px, -2px);
+            }
+        }
+
+        @keyframes glitch-2 {
+            0%,
+            100% {
+                transform: translate(0, 0);
+            }
+
+            10% {
+                transform: translate(2px, 2px);
+            }
+
+            20% {
+                transform: translate(-2px, -2px);
+            }
+
+            30% {
+                transform: translate(2px, -2px);
+            }
+
+            40% {
+                transform: translate(-2px, 2px);
+            }
+
+            50% {
+                transform: translate(2px, 2px);
+            }
+
+            60% {
+                transform: translate(-2px, -2px);
+            }
+
+            70% {
+                transform: translate(2px, -2px);
+            }
+
+            80% {
+                transform: translate(-2px, 2px);
+            }
+
+            90% {
+                transform: translate(2px, 2px);
+            }
+        }
+
+        .glitch-effect {
+            position: relative;
+            display: inline-block;
+            isolation: isolate;
+        }
+
+        .glitch-effect::before,
+        .glitch-effect::after {
+            content: var(--glitch-text, attr(data-text));
+            position: absolute;
+            inset: 0;
+            opacity: 0;
+            pointer-events: none;
+        }
+
+        .glitch-effect:hover::before {
+            animation: glitch-1 0.3s infinite;
+            color: var(--color-accent);
+            opacity: 0.7;
+            z-index: -1;
+        }
+
+        .glitch-effect:hover::after {
+            animation: glitch-2 0.3s infinite;
+            color: var(--color-primary);
+            opacity: 0.7;
+            z-index: -2;
+        }
+
+        .nav-surface {
+            background: linear-gradient(
+                        180deg,
+                        color-mix(in srgb, var(--color-base-100) 92%, var(--color-secondary) 8%) 0%,
+                        color-mix(in srgb, var(--color-base-100) 96%, var(--color-primary) 4%) 100%
+                    );
+            border-bottom: var(--border) solid var(--nr-border-color);
+            box-shadow: var(--nr-shadow-sm);
+            backdrop-filter: blur(10px);
+        }
+
+        .nav-shell {
+            position: relative;
+            width: 100%;
+        }
+
+        .nav-brand {
+            text-decoration: none;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .btn-nav {
+            text-transform: uppercase;
+            letter-spacing: 0.28em;
+            font-weight: 800;
+            gap: 0.5rem;
+            border-width: var(--border);
+            border-color: var(--nr-border-color);
+            box-shadow: var(--nr-shadow-sm);
+            transition: transform 0.25s ease, box-shadow 0.25s ease, background 0.25s ease, color 0.25s ease;
+        }
+
+        .btn-nav-default {
+            background: var(--color-base-100);
+            color: var(--color-base-content);
+        }
+
+        .btn-nav-default:hover,
+        .btn-nav-default:focus-visible {
+            transform: translate(-3px, -3px);
+            box-shadow: var(--nr-shadow-base);
+            outline: none;
+        }
+
+        .btn-nav-active {
+            background: var(--nr-border-color);
+            color: var(--color-base-100);
+            transform: translate(-3px, -3px);
+            box-shadow: var(--nr-shadow-base);
+        }
+
+        .btn-nav-active:hover,
+        .btn-nav-active:focus-visible {
+            outline: none;
+        }
+
+        .btn-nav-block {
+            width: 100%;
+            justify-content: flex-start;
+        }
+
+        .nav-chevron {
+            transition: transform 0.25s ease;
+        }
+
+        .nav-dropdown-panel {
+            border: 4px solid var(--nr-border-color);
+            background: var(--color-base-100);
+            box-shadow: var(--nr-shadow-lg);
+        }
+
+        .nav-dropdown-link {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+            padding: 0.75rem;
+            border: 2px solid transparent;
+            background: var(--color-base-100);
+            transition: transform 0.25s ease, border-color 0.25s ease, background 0.25s ease;
+        }
+
+        .nav-dropdown-link:hover,
+        .nav-dropdown-link:focus-visible {
+            border-color: var(--nr-border-color);
+            background: color-mix(in srgb, var(--color-base-100) 80%, var(--color-info) 20%);
+            transform: translate(-3px, -3px);
+            outline: none;
+        }
+
+        .dropdown.dropdown-hover:hover > label .nav-chevron,
+        .dropdown.dropdown-open > label .nav-chevron,
+        .dropdown:focus-within > label .nav-chevron {
+            transform: rotate(180deg);
+        }
+
+        .nav-mobile-toggle summary {
+            cursor: pointer;
+            list-style: none;
+        }
+
+        .nav-mobile-toggle summary::-webkit-details-marker {
+            display: none;
+        }
+
+        .nav-mobile-toggle[open] > summary {
+            transform: translate(-4px, -4px);
+            background: color-mix(in srgb, var(--color-base-100) 85%, var(--color-secondary) 15%);
+            box-shadow: var(--nr-shadow-base);
+        }
+
+        .nav-mobile-toggle[open] .icon-open {
+            display: none;
+        }
+
+        .nav-mobile-toggle[open] .icon-close {
+            display: flex;
+        }
+
+        .nav-mobile-panel {
+            position: absolute;
+            top: calc(100% + 0.75rem);
+            right: 0;
+            left: auto;
+            width: min(18rem, 85vw);
+            border: 4px solid var(--nr-border-color);
+            background: var(--color-base-100);
+            box-shadow: var(--nr-shadow-lg);
+            padding: 1.25rem;
+        }
+
+        .nav-mobile-panel .menu {
+            width: 100%;
+        }
+
+        .nav-mobile-status {
+            align-self: flex-start;
+            letter-spacing: 0.3em;
+        }
+
+        .texture-grid-paper {
+            position: relative;
+            isolation: isolate;
+            background-color: #e6f6f7;
+        }
+
+        .texture-grid-paper::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            background-image:
+                linear-gradient(to right, rgba(0, 0, 0, 0.08) 1px, transparent 1px),
+                linear-gradient(to bottom, rgba(0, 0, 0, 0.08) 1px, transparent 1px),
+                linear-gradient(to right, rgba(0, 0, 0, 0.03) 1px, transparent 1px),
+                linear-gradient(to bottom, rgba(0, 0, 0, 0.03) 1px, transparent 1px);
+            background-size: 80px 80px, 80px 80px, 16px 16px, 16px 16px;
+            opacity: 0.55;
+            mix-blend-mode: multiply;
+            z-index: -1;
+        }
+
+        .texture-grid-paper::after {
+            content: "";
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            background-image:
+                repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0, 0, 0, 0.04) 2px, rgba(0, 0, 0, 0.04) 4px),
+                repeating-linear-gradient(90deg, transparent, transparent 2px, rgba(0, 0, 0, 0.04) 2px, rgba(0, 0, 0, 0.04) 4px);
+            opacity: 0.2;
+            mix-blend-mode: multiply;
+            z-index: -1;
+        }
+
+        .texture-grain {
+            position: relative;
+            isolation: isolate;
+        }
+
+        .texture-grain::before {
+            content: "";
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            background-image:
+                repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(0, 0, 0, 0.04) 2px, rgba(0, 0, 0, 0.04) 4px),
+                repeating-linear-gradient(90deg, transparent, transparent 2px, rgba(0, 0, 0, 0.04) 2px, rgba(0, 0, 0, 0.04) 4px);
+            opacity: 0.35;
+            mix-blend-mode: multiply;
+            z-index: -1;
+        }
+
+        .hero-badge {
+            --badge-rotation: 0deg;
+            --badge-rotation-hover-offset: 0deg;
+            --badge-translate-x: 0px;
+            --badge-translate-y: 0px;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+            font-family: "Space Grotesk", var(--tw-font-sans, ui-sans-serif, system-ui);
+            font-weight: 800;
+            transform: translate(var(--badge-translate-x), var(--badge-translate-y))
+                rotate(calc(var(--badge-rotation, 0deg) + var(--badge-rotation-hover-offset, 0deg)));
+            transition: transform 0.25s ease, box-shadow 0.25s ease;
+        }
+
+        .hero-badge-floating {
+            box-shadow: var(--nr-shadow-sm);
+        }
+
+        .hero-badge-sticker {
+            box-shadow: var(--nr-shadow-base);
+        }
+
+        .hero-badge-floating:hover,
+        .hero-badge-floating:focus-visible,
+        .hero-badge-sticker:hover,
+        .hero-badge-sticker:focus-visible {
+            --badge-translate-x: -4px;
+            --badge-translate-y: -4px;
+            --badge-rotation-hover-offset: -2deg;
+            box-shadow: var(--nr-shadow-lg);
+            outline: none;
+        }
+
+        @keyframes hero-square-spin {
+            0% {
+                transform: rotate(0deg) scale(1);
+            }
+
+            50% {
+                transform: rotate(180deg) scale(1.08);
+            }
+
+            100% {
+                transform: rotate(360deg) scale(1);
+            }
+        }
+
+        @keyframes hero-circle-bob {
+            0% {
+                transform: rotate(360deg) translateY(0);
+            }
+
+            50% {
+                transform: rotate(180deg) translateY(-12px);
+            }
+
+            100% {
+                transform: rotate(0deg) translateY(0);
+            }
+        }
+
+        @keyframes hero-bar-wave {
+            0% {
+                transform: rotate(45deg) translateX(0);
+            }
+
+            50% {
+                transform: rotate(30deg) translateX(12px);
+            }
+
+            100% {
+                transform: rotate(45deg) translateX(0);
+            }
+        }
+
+        .hero-portrait-cluster {
+            position: relative;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 2.5rem;
+        }
+
+        .hero-portrait-frame {
+            position: relative;
+            transform: rotate(2deg);
+            transition: transform 0.35s ease, box-shadow 0.35s ease;
+        }
+
+        .hero-portrait-inner {
+            background: linear-gradient(135deg, #22d3ee 0%, #bef264 50%, #facc15 100%);
+            border: 6px solid #000000;
+            box-shadow: 20px 20px 0px 0px rgba(0, 0, 0, 1);
+            padding: 0.75rem;
+            transition: transform 0.35s ease;
+        }
+
+        .hero-portrait-cluster:hover .hero-portrait-frame {
+            transform: rotate(5deg) translate(-6px, -6px);
+        }
+
+        .hero-portrait-cluster:hover .hero-portrait-inner {
+            transform: translate(6px, 6px) rotate(-1deg);
+        }
+
+        .hero-shape {
+            position: absolute;
+            pointer-events: none;
+            opacity: 0.75;
+            z-index: -1;
+            transition: transform 0.35s ease;
+        }
+
+        .hero-shape-square {
+            top: 0;
+            left: 0;
+            width: 5rem;
+            height: 5rem;
+            border: 4px solid #000000;
+            background: #d946ef;
+            box-shadow: 4px 4px 0px 0px rgba(0, 0, 0, 1);
+            animation: hero-square-spin 20s linear infinite;
+        }
+
+        .hero-shape-circle {
+            right: 1rem;
+            bottom: 1rem;
+            width: 4rem;
+            height: 4rem;
+            border-radius: 9999px;
+            border: 4px solid #000000;
+            background: #22d3ee;
+            box-shadow: 6px 6px 0px 0px rgba(0, 0, 0, 1);
+            animation: hero-circle-bob 12s ease-in-out infinite;
+        }
+
+        .hero-shape-bar {
+            top: 50%;
+            right: -2rem;
+            width: 3rem;
+            height: 6.5rem;
+            border: 4px solid #000000;
+            background: #fde047;
+            box-shadow: 4px 4px 0px 0px rgba(0, 0, 0, 1);
+            transform: rotate(45deg);
+            transform-origin: center;
+            animation: hero-bar-wave 10s ease-in-out infinite;
+        }
+
+        .hero-portrait-cluster:hover .hero-shape-square {
+            transform: rotate(-12deg) translate(-8px, -8px);
+        }
+
+        .hero-portrait-cluster:hover .hero-shape-circle {
+            transform: translate(8px, 8px) scale(1.05);
+        }
+
+        .hero-portrait-cluster:hover .hero-shape-bar {
+            transform: rotate(60deg) translate(6px, -10px);
+        }
+
+        .hero-btn {
+            letter-spacing: 0.28em;
+            text-transform: uppercase;
+            font-weight: 800;
+            gap: 0.75rem;
+            box-shadow: var(--nr-shadow-base);
+            transition: transform 0.25s ease, box-shadow 0.25s ease;
+        }
+
+        .hero-btn:hover,
+        .hero-btn:focus-visible {
+            transform: translate(-6px, -6px);
+            box-shadow: var(--nr-shadow-xl);
+            outline: none;
+        }
+
+        .hero-btn-primary {
+            background-image: linear-gradient(90deg, #22d3ee 0%, #bef264 45%, #facc15 100%);
+            color: #000000;
+            border-color: #000000;
+        }
+
+        .hero-btn-secondary {
+            background-color: #ffffff;
+            color: #000000;
+            border-color: #000000;
+        }
+
+        .hero-scroll-btn {
+            border-width: 4px;
+            border-color: #000000;
+            box-shadow: var(--nr-shadow-sm);
+            transition: transform 0.25s ease, box-shadow 0.25s ease;
+            background-color: #ffffff;
+        }
+
+        .hero-scroll-btn:hover,
+        .hero-scroll-btn:focus-visible {
+            transform: translateY(-6px);
+            box-shadow: var(--nr-shadow-base);
+            outline: none;
+        }
+
+        .hero-statement-card {
+            position: relative;
+            border: 4px solid #000000;
+            background: #ffffff;
+            box-shadow: 8px 8px 0px 0px rgba(0, 0, 0, 1);
+        }
+
+        .hero-statement-card .card-body {
+            padding: clamp(1.75rem, 3vw, 2.75rem);
+            gap: 0;
+        }
+
+        .hero-statement-highlight {
+            display: inline-block;
+            padding: 0.25em 0.6em;
+            margin: 0 0.2em;
+            border: 3px solid #000000;
+            background: #d9f99d;
+            font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        }
+
+        .hero-statement-accent-square {
+            top: -1.75rem;
+            right: -1.75rem;
+            width: 5rem;
+            height: 5rem;
+            border: 4px solid #000000;
+            background: linear-gradient(135deg, #22d3ee 0%, #a855f7 100%);
+            box-shadow: 6px 6px 0px 0px rgba(0, 0, 0, 1);
+        }
+
+        .hero-statement-accent-bar {
+            bottom: -2.25rem;
+            left: -1.75rem;
+            width: 3.5rem;
+            height: 7rem;
+            border: 4px solid #000000;
+            background: linear-gradient(180deg, #ec4899 0%, #facc15 100%);
+            box-shadow: 4px 4px 0px 0px rgba(0, 0, 0, 1);
+            transform: rotate(-12deg);
+        }
+
     }
 
     @layer utilities {


### PR DESCRIPTION
## Summary
- rebuild the homepage hero to consume DaisyUI badges, cards, and buttons while keeping the portrait stickers data-driven
- rework the navbar around DaisyUI navbar, menu, and dropdown patterns with new utility classes for pill links and drawers
- refresh the navigation and hero showcase pages to demonstrate the updated components

## Testing
- pnpm astro check

------
https://chatgpt.com/codex/tasks/task_e_68defac6bd54832c9b35e63540ed6164